### PR TITLE
add get started doc

### DIFF
--- a/docs/get-started/map-struct-in-2-minutes.md
+++ b/docs/get-started/map-struct-in-2-minutes.md
@@ -1,0 +1,44 @@
+# 快速入门MapStruct (2分钟)
+
+:::code-group
+
+```java [Car.java]
+public class Car {
+ 
+    private String make;
+    private int numberOfSeats;
+    private CarType type;
+ 
+    //constructor, getters, setters etc.
+}
+```
+
+```java [CarDto.java]
+public class CarDto {
+ 
+    private String make;
+    private int seatCount;
+    private String type;
+ 
+    //constructor, getters, setters etc.
+}
+```
+:::
+
+
+:::code-group
+```java [CarMapper.java]
+@Mapper
+public interface CarMapper {
+ 
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+ 
+    @Mapping(source = "numberOfSeats", target = "seatCount")
+    CarDto carToCarDto(Car car);
+}
+```
+:::
+
+## 参考
+- [MapStruct官方网站,点击get started](https://mapstruct.org/)
+- [在vitepress中使用code group](https://vitepress.dev/guide/markdown#code-groups)


### PR DESCRIPTION
## Task
<!-- Describe the issue or problem -->
1. add "get started" mapstruct document to project

follow up work, add more doc including

```
MapStruct in 2 Minutes

The following shows how to map two objects using MapStruct.

Let's assume we have a class representing cars (e.g. a JPA entity) and an accompanying data transfer object (DTO).

Both types are rather similar, only the seat count attributes have different names and the type attribute is of a special enum type in the Car class but is a plain string in the DTO.
[Car.java](https://github.com/atomeocean/atomeocean-cn-mapstruct/compare/add-pr-0918?expand=1)
[CarDto.java](https://github.com/atomeocean/atomeocean-cn-mapstruct/compare/add-pr-0918?expand=1)
public class Car {
 
    private String make;
    private int numberOfSeats;
    private CarType type;
 
    //constructor, getters, setters etc.
}
The mapper interface

To generate a mapper for creating a CarDto object out of a Car object, a mapper interface needs to be defined:
[CarMapper.java](https://github.com/atomeocean/atomeocean-cn-mapstruct/compare/add-pr-0918?expand=1)
@Mapper 1
public interface CarMapper {
 
    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class ); 3
 
    @Mapping(source = "numberOfSeats", target = "seatCount")
    CarDto carToCarDto(Car car); 2
}
The @Mapper annotation 1 marks the interface as mapping interface and lets the MapStruct processor kick in during compilation.

The actual mapping method 2 expects the source object as parameter and returns the target object. Its name can be freely chosen.
For attributes with different names in source and target object, the @Mapping annotation can be used to configure the names.

Where required and possible a type conversion will be executed for attributes with different types in source and target, e.g. the type attribute will be converted from the enumeration type into a string.
Of course there can be multiple mapping methods in one interface, for all of which an implementation will be generated by MapStruct.

An instance of the interface implementation can be retrieved from the Mappers class. By convention, the interface declares a member INSTANCE 3, providing clients access to the mapper implementation.
```

## Testing
<!--
Describe the testing you did including unit tests, manual testing, etc 
run unit tests: mvn clean test
-->
- local site looks good